### PR TITLE
添加支持mlx-lm，适用于MacOS 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,7 +8,7 @@
 
 ## ✨ 特性
 
-- 🚀 **多种后端加速**: 支持`vllm`、`sglang`、`llama cpp`多种加速策略
+- 🚀 **多种后端加速**: 支持`vllm`、`sglang`、`llama cpp`、`mlx-lm` 多种加速策略
 - 🎯 **高并发**: 采用动态批处理，极大提高并发
 - 🎛️ **全参数控制**: 音调、语速、音色温度等全方位可调
 - 📱 **轻量部署**: 最小依赖，基于Flask和fastapi快速启动
@@ -77,6 +77,16 @@ pip install -r requirements.txt
 
   具体参考链接：https://github.com/sgl-project/sglang
 
+
+- **mlx-lm**
+
+  在Apple Silicon上运行大型语言模型，适用于MacOS。
+    ```bash
+    pip install mlx-lm
+    ```
+  具体参考链接：https://github.com/ml-explore/mlx-lm
+
+
 ### 启动
 
 1. 克隆项目仓库
@@ -88,12 +98,12 @@ cd Fast-Spark-TTS
 
 2. 启动SparkTTS API服务
 
-`engine`可根据自己的环境，选择对应的推理引擎。目前支持`torch`、`vllm`、`sglang`、`llama-cpp`。
+`backend`可根据自己的环境，选择对应的推理引擎。目前支持`torch`、`vllm`、`sglang`、`llama-cpp`、`mlx-lm`。
 
 ```bash
 python server.py \
 --model_path Spark-TTS-0.5B \  # 可修改为自己的模型地址
---backend vllm \  # vllm、sglang、torch、llama-cpp任选一个
+--backend vllm \  # vllm、sglang、torch、llama-cpp、mlx-lm任选一个
 --llm_device cuda \
 --tokenizer_device cuda \
 --detokenizer_device cuda \

--- a/fast_tts/engine/spark_engine.py
+++ b/fast_tts/engine/spark_engine.py
@@ -201,7 +201,7 @@ class AsyncSparkEngine(BaseEngine):
             llm_device: Literal["cpu", "cuda", "mps", "auto"] | str = "auto",
             tokenizer_device: Literal["cpu", "cuda", "mps", "auto"] | str = "auto",
             detokenizer_device: Literal["cpu", "cuda", "mps", "auto"] | str = "auto",
-            backend: Literal["vllm", "llama-cpp", "sglang", "torch"] = "torch",
+            backend: Literal["vllm", "llama-cpp", "sglang", "torch", "mlx-lm"] = "torch",
             wav2vec_attn_implementation: Optional[Literal["sdpa", "flash_attention_2", "eager"]] = None,
             llm_attn_implementation: Optional[Literal["sdpa", "flash_attention_2", "eager"]] = None,
             torch_dtype: Literal['float16', "bfloat16", 'float32', 'auto'] = "auto",

--- a/fast_tts/import_utils.py
+++ b/fast_tts/import_utils.py
@@ -89,6 +89,7 @@ def _is_package_available(
 _vllm_available = _is_package_available("vllm")
 _sglang_available = _is_package_available("sglang")
 _llama_cpp_available = bool(importlib.util.find_spec("llama_cpp") is not None)
+_mlx_lm_available = bool(importlib.util.find_spec("mlx_lm") is not None)
 
 
 def is_vllm_available():
@@ -101,3 +102,6 @@ def is_sglang_available():
 
 def is_llama_cpp_available():
     return _llama_cpp_available
+
+def is_mlx_lm_available():
+    return _mlx_lm_available

--- a/fast_tts/llm/init_llm.py
+++ b/fast_tts/llm/init_llm.py
@@ -7,7 +7,7 @@ from .base_llm import BaseLLM
 from ..import_utils import (
     is_llama_cpp_available,
     is_vllm_available,
-    is_sglang_available
+    is_sglang_available, is_mlx_lm_available
 )
 from ..logger import get_logger
 
@@ -16,7 +16,7 @@ logger = get_logger()
 
 def initialize_llm(
         model_path: str,
-        backend: Literal["vllm", "llama-cpp", "sglang", "torch"] = "torch",
+        backend: Literal["vllm", "llama-cpp", "sglang", "torch", "mlx-lm"] = "torch",
         max_length: int = 32768,
         device: Literal["cpu", "cuda", "auto"] | str = "auto",
         attn_implementation: Optional[Literal["sdpa", "flash_attention_2", "eager"]] = None,
@@ -89,5 +89,17 @@ def initialize_llm(
             stop_tokens=stop_tokens,
             stop_token_ids=stop_token_ids,
             **kwargs)
+
+    elif backend == "mlx-lm":
+        if not is_mlx_lm_available():
+            raise ImportError("mlx-lm is not installed. Please install it with `pip install mlx-lm`.")
+        from .mlx_lm_generator import MlxLmGenerator
+        return MlxLmGenerator(
+            model_path=model_path,
+            max_length=max_length,
+            stop_tokens=stop_tokens,
+            stop_token_ids=stop_token_ids,
+            **kwargs)
+
     else:
         raise ValueError(f"Unknown backend: {backend}")

--- a/fast_tts/llm/mlx_lm_generator.py
+++ b/fast_tts/llm/mlx_lm_generator.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Time      :2025/4/01 11:00
+# Author    :Dylanoy
+from typing import Optional, AsyncIterator
+import asyncio
+import uuid
+
+from .base_llm import BaseLLM
+
+__all__ = ["MlxLmGenerator"]
+
+
+class MlxLmGenerator(BaseLLM):
+    def __init__(
+            self,
+            model_path: str,
+            max_length: int = 32768,
+            stop_tokens: Optional[list[str]] = None,
+            stop_token_ids: Optional[list[int]] = None,
+            **kwargs):
+        from mlx_lm import load, generate, stream_generate
+
+        # Load the model and tokenizer
+        self.model, tokenizer = load(model_path)
+
+        # Store the generate function for later use
+        self.generate_fn = generate
+        self.stream_generate_fn = stream_generate
+
+        super(MlxLmGenerator, self).__init__(
+            tokenizer=model_path,
+            max_length=max_length,
+            stop_tokens=stop_tokens,
+            stop_token_ids=stop_token_ids,
+        )
+
+    async def random_uid(self):
+        """Generate a random UUID for request tracking"""
+        return str(uuid.uuid4())
+
+    async def async_generate(
+            self,
+            prompt: str,
+            max_tokens: int = 1024,
+            temperature: float = 0.9,
+            top_p: float = 0.9,
+            top_k: int = 50,
+            **kwargs
+    ) -> str:
+
+        result = self.generate_fn(
+            self.model,
+            self.tokenizer,
+            prompt=prompt,
+            verbose=False,
+            max_tokens=max_tokens,
+            **kwargs)
+
+        return result
+
+    async def async_stream_generate(
+            self,
+            prompt: str,
+            max_tokens: int = 1024,
+            temperature: float = 0.9,
+            top_p: float = 0.9,
+            top_k: int = 50,
+            **kwargs) -> AsyncIterator[str]:
+
+        for response in self.stream_generate_fn(self.model, self.tokenizer, prompt, max_tokens=max_tokens):
+            yield response.text

--- a/fast_tts/llm/sglang_generator.py
+++ b/fast_tts/llm/sglang_generator.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Time      :2025/3/29 10:57
 # Author    :Hui Huang
-from typing import Optional, AsyncIterator
+from typing import Optional, AsyncIterator, List
 
 from sglang.srt.entrypoints.engine import Engine
 from sglang.srt.server_args import PortArgs, ServerArgs
@@ -18,6 +18,8 @@ class SglangGenerator(BaseLLM):
                  max_length: int = 32768,
                  gpu_memory_utilization: Optional[float] = None,
                  device: str = "cuda",
+                 stop_tokens: Optional[list[str]] = None,
+                 stop_token_ids: Optional[List[int]] = None,
                  **kwargs):
         engine_kwargs = dict(
             model_path=model_path,
@@ -37,6 +39,8 @@ class SglangGenerator(BaseLLM):
         super(SglangGenerator, self).__init__(
             tokenizer=model_path,
             max_length=max_length,
+            stop_tokens=stop_tokens,
+            stop_token_ids=stop_token_ids,
         )
 
     async def async_generate(

--- a/server.py
+++ b/server.py
@@ -418,8 +418,8 @@ if __name__ == '__main__':
     parser.add_argument("--model_path", type=str, required=True,
                         help="模型路径")
     parser.add_argument("--backend", type=str, required=True,
-                        choices=["llama-cpp", "vllm", "sglang", "torch"],
-                        help="引擎类型，如 llama-cpp、vllm、sglang 或 torch")
+                        choices=["llama-cpp", "vllm", "sglang", "torch", "mlx-lm"],
+                        help="引擎类型，如 llama-cpp、vllm、sglang、mlx-lm 或 torch")
     parser.add_argument("--llm_device", type=str, default="auto",
                         help="llm 设备，例如 cpu 或 cuda:0")
     parser.add_argument("--tokenizer_device", type=str, default="auto",

--- a/speed_test.py
+++ b/speed_test.py
@@ -38,7 +38,7 @@ generate_config = dict(
 
 async def run(
         model_path: str,
-        backend: Literal["vllm", "llama-cpp", "sglang", "torch"] = "torch",
+        backend: Literal["vllm", "llama-cpp", "sglang", "torch", "mlx-lm"] = "torch",
         device: Literal["cpu", "cuda", "auto"] | str = "auto"
 ):
     model_kwargs = {
@@ -84,4 +84,4 @@ async def run(
 
 
 if __name__ == '__main__':
-    asyncio.run(run(backend="sglang", model_path="Spark-TTS-0.5B", device="cuda"))
+    asyncio.run(run(backend="torch", model_path="park-TTS-0.5B", device="auto"))


### PR DESCRIPTION
## 系统信息

| 配置项        | 值                           |
| :-----------: | :--------------------------: |
| **操作系统**   | macOS Version 15.3.2 (24D81) |
| **设备**       | MacBook M4 Pro              |
| **Python 版本** | 3.12.8                     |
| **CPU**       | Apple M4 Pro                |
| **CPU 核心数** | 12                          |
| **内存**       | 24.0 GB                     |
| **PyTorch 版本** | 2.6.0                     |

---

## 推理性能对比

### 短文本

| 模型   | 推理耗时 (s)          | 输出音频长度 (s) | RTF (Real Time Factor) |
| :----: | :-------------------: | :--------------: | :---------------------: |
| **mlx-lm** | 4.253132582991384   | 7.68            | 0.5537933050770032     |
| **torch**  | 16.978848250000738  | 7.68            | 2.2107875325521795     |

### 长文本

| 模型   | 推理耗时 (s)           | 输出音频长度 (s) | RTF (Real Time Factor) |
| :----: | :--------------------: | :--------------: | :---------------------: |
| **mlx-lm** | 217.15768220898462   | 377.9           | 0.5746432447975248     |
| **torch**  | 198.29628783400403   | 120.82          | 1.6412538307730844     |

---

## 性能简要分析

- **mlx-lm** 在短文本场景下的推理速度更快（4.25s vs 16.98s），且输出同样长度的音频时，RTF 更小（约 0.55 vs 2.21）。
- 在长文本场景中，**mlx-lm** 生成的音频更长（377.9s vs 120.82s），推理耗时略高（217.16s vs 198.30s），不过 RTF 依然更低（约 0.57 vs 1.64），意味着在同等长度输出时，mlx-lm 的整体推理效率更高。
- 上述结果在苹果 M4 Pro、12 核 CPU、24GB 内存、PyTorch 2.6.0 环境下进行。
